### PR TITLE
Fix ansible-lint problems

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,4 +2,4 @@
 subid_users: []
 ansible_become: true
 subuid_bitshift: 16
-subgid_bitshift: "{{subuid_bitshift}}"
+subgid_bitshift: "{{ subuid_bitshift }}"

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -12,6 +12,6 @@ galaxy_info:
 
   min_ansible_version: "3.0"
 
-  galaxy_tags: ["subuid,subgid"]
+  galaxy_tags: ["subuid", "subgid"]
 
 dependencies: []

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -4,7 +4,7 @@
   diff: true
   tasks:
     - name: Set users for role
-      set_fact:
+      ansible.builtin.set_fact:
         subid_users:
           - james
           - thorsten

--- a/tasks/configure-user.yml
+++ b/tasks/configure-user.yml
@@ -2,7 +2,7 @@
 # https://eengstrom.github.io/musings/generate-non-contiguous-subuid-subgid-maps-for-rootless-podman
 
 - name: Get user infos
-  getent:
+  ansible.builtin.getent:
     database: passwd
     key: "{{ subid_user }}"
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,5 +1,5 @@
 - name: Configure each user
-  include_tasks: configure-user.yml
+  ansible.builtin.include_tasks: configure-user.yml
   loop: "{{ subid_users }}"
   loop_control:
     loop_var: "subid_user"


### PR DESCRIPTION
Fixes all problems reported by ansible-lint.

Original lint report:
```
jinja[spacing]: Jinja2 spacing could be improved: {{subuid_bitshift}} -> {{ subuid_bitshift }} (warning)
defaults/main.yml:5 Jinja2 template rewrite recommendation: `{{ subuid_bitshift }}`.

meta-no-tags: Tags must contain lowercase letters and digits only., invalid: 'subuid,subgid'
meta/main.yml:1

fqcn[action-core]: Use FQCN for builtin module actions (set_fact).
molecule/default/converge.yml:6 Use `ansible.builtin.set_fact` or `ansible.legacy.set_fact` instead.

fqcn[action-core]: Use FQCN for builtin module actions (getent).
tasks/configure-user.yml:4 Use `ansible.builtin.getent` or `ansible.legacy.getent` instead.

fqcn[action-core]: Use FQCN for builtin module actions (include_tasks).
tasks/main.yml:1 Use `ansible.builtin.include_tasks` or `ansible.legacy.include_tasks` instead.
```